### PR TITLE
Updated anonymous paths to enable Swagger UI. 

### DIFF
--- a/src/main/java/engineering/everest/starterkit/security/config/ResourceServerConfig.java
+++ b/src/main/java/engineering/everest/starterkit/security/config/ResourceServerConfig.java
@@ -32,6 +32,8 @@ public class ResourceServerConfig extends ResourceServerConfigurerAdapter {
     private static final String SPRING_ACTUATOR_HEALTH_API = "/actuator/health/**";
     private static final String GUEST_API = "/api/guest";
     private static final String SWAGGER_API_DOCUMENTATION = "/api/doc/**";
+    private static final String SWAGGER_UI = "/swagger-ui/**";
+    private static final String SWAGGER_RESOURCES = "/swagger-resources/**";
 
     private static final String[] ADMIN_USERS_PATHS = {
             ADMIN_API,
@@ -48,7 +50,9 @@ public class ResourceServerConfig extends ResourceServerConfigurerAdapter {
             VERSION_API,
             SPRING_ACTUATOR_HEALTH_API,
             GUEST_API,
-            SWAGGER_API_DOCUMENTATION
+            SWAGGER_API_DOCUMENTATION,
+            SWAGGER_UI,
+            SWAGGER_RESOURCES
     };
 
     private final JwtAccessTokenConverter jwtAccessTokenConverter;


### PR DESCRIPTION
## Proposed changes
This is a minor change that permits anonymous access to `/swagger-ui` and `/swagger-resources`. This is to reinstate the Swagger UI (even before an update to Springfox Swagger 3.0) but needs to be handled more cleanly (as part of lhotse#30).

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] My local build passed (You ran `./gradlew clean build` without failures)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] I have assigned a label to the PR 

